### PR TITLE
Add chat room server example

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -1,0 +1,19 @@
+# WebSocket Chat Room Example
+
+This is a simple chat room server implemented with Python's `websockets` library.
+It supports multiple rooms and private messages between users.
+
+## Running the server
+
+1. Install the required dependency:
+   ```bash
+   pip install websockets
+   ```
+2. Run the server:
+   ```bash
+   python3 server.py
+   ```
+3. Open `static/index.html` in your browser and connect using a username and room.
+
+Multiple clients can connect to the same room or different rooms. Use the
+"private to" field to send a private message to a specific user.

--- a/chat/server.py
+++ b/chat/server.py
@@ -1,0 +1,64 @@
+import asyncio
+import json
+import websockets
+from websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
+
+# Stores room name -> set of connected websockets
+rooms = {}
+
+# Stores websocket -> username
+users = {}
+
+async def register(ws, username, room):
+    users[ws] = username
+    if room not in rooms:
+        rooms[room] = set()
+    rooms[room].add(ws)
+    await notify_room(room, f"{username} joined {room}")
+
+async def unregister(ws):
+    username = users.get(ws)
+    if username is None:
+        return
+    for r, sockets in list(rooms.items()):
+        if ws in sockets:
+            sockets.remove(ws)
+            await notify_room(r, f"{username} left {r}")
+            if not sockets:
+                rooms.pop(r)
+    users.pop(ws, None)
+
+async def notify_room(room, message):
+    if room not in rooms:
+        return
+    for ws in rooms[room]:
+        await ws.send(json.dumps({"type": "room_message", "room": room, "message": message}))
+
+async def send_private(sender_ws, target, message):
+    for ws, name in users.items():
+        if name == target:
+            await ws.send(json.dumps({"type": "private_message", "from": users[sender_ws], "message": message}))
+            break
+
+async def handler(ws):
+    try:
+        async for msg in ws:
+            data = json.loads(msg)
+            if data["action"] == "join":
+                await register(ws, data["username"], data["room"])
+            elif data["action"] == "message":
+                await notify_room(data["room"], f"{users[ws]}: {data['message']}")
+            elif data["action"] == "private":
+                await send_private(ws, data["to"], data["message"])
+    except (ConnectionClosedOK, ConnectionClosedError):
+        pass
+    finally:
+        await unregister(ws)
+
+async def main():
+    async with websockets.serve(handler, "0.0.0.0", 8765):
+        print("Chat server started on ws://0.0.0.0:8765")
+        await asyncio.Future()  # run forever
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/chat/static/index.html
+++ b/chat/static/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Chat Room</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        #chat { height: 300px; overflow-y: scroll; border: 1px solid #ccc; padding: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Chat Room</h1>
+    <label>Username: <input id="username" /></label>
+    <label>Room: <input id="room" value="lobby" /></label>
+    <button onclick="connect()">Connect</button>
+    <div id="chat"></div>
+    <input id="message" placeholder="message" />
+    <button onclick="sendMessage()">Send</button>
+    <input id="private_to" placeholder="private to" />
+    <input id="private_msg" placeholder="private message" />
+    <button onclick="sendPrivate()">Send Private</button>
+
+<script>
+let ws;
+function connect() {
+    const username = document.getElementById('username').value;
+    const room = document.getElementById('room').value;
+    ws = new WebSocket('ws://' + location.host + ':8765');
+    ws.onopen = () => {
+        ws.send(JSON.stringify({action: 'join', username: username, room: room}));
+    };
+    ws.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        const chat = document.getElementById('chat');
+        if (data.type === 'room_message') {
+            chat.innerHTML += '<div>['+data.room+'] ' + data.message + '</div>';
+        } else if (data.type === 'private_message') {
+            chat.innerHTML += '<div>(private from '+data.from+') ' + data.message + '</div>';
+        }
+        chat.scrollTop = chat.scrollHeight;
+    };
+}
+
+function sendMessage() {
+    const room = document.getElementById('room').value;
+    const msg = document.getElementById('message').value;
+    ws.send(JSON.stringify({action: 'message', room: room, message: msg}));
+}
+
+function sendPrivate() {
+    const to = document.getElementById('private_to').value;
+    const msg = document.getElementById('private_msg').value;
+    ws.send(JSON.stringify({action: 'private', to: to, message: msg}));
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a WebSocket chat server using Python
- provide a simple HTML client
- document running the server

## Testing
- `python3 -m py_compile chat/server.py`

------
https://chatgpt.com/codex/tasks/task_e_6841284c97d8832a8304fd0f92af5324