### PR TITLE
Add simple Nginx control panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/nginx_panel/README.md
+++ b/nginx_panel/README.md
@@ -1,0 +1,39 @@
+# Simple Nginx Control Panel
+
+This is a minimal Flask-based control panel for managing Nginx on Ubuntu.
+It exposes HTTP endpoints to start, stop and reload the Nginx service as well
+as create new server blocks automatically.
+
+## Features
+- View Nginx service status
+- Start, stop and reload Nginx
+- List available server blocks
+- Create new server blocks on the fly
+
+## Requirements
+- Python 3.11+
+- `flask` Python package
+- Root privileges to manage Nginx
+
+Install dependencies with:
+```bash
+pip install flask
+```
+
+## Running
+```bash
+sudo python3 panel.py
+```
+The application listens on port `8080`.
+
+## Example requests
+Check service status:
+```bash
+curl http://localhost:8080/
+```
+Create a new site:
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"domain": "example.com", "root": "/var/www/example"}' \
+     http://localhost:8080/sites
+```

--- a/nginx_panel/panel.py
+++ b/nginx_panel/panel.py
@@ -1,0 +1,74 @@
+import os
+import subprocess
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+NGINX_SITES_AVAILABLE = '/etc/nginx/sites-available'
+NGINX_SITES_ENABLED = '/etc/nginx/sites-enabled'
+
+
+def run_command(cmd):
+    """Run shell command and return output."""
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return result.stdout.strip()
+
+
+@app.route('/')
+def index():
+    status = run_command('systemctl is-active nginx')
+    return jsonify({'nginx_status': status})
+
+
+@app.route('/start', methods=['POST'])
+def start_nginx():
+    output = run_command('systemctl start nginx')
+    return jsonify({'output': output})
+
+
+@app.route('/stop', methods=['POST'])
+def stop_nginx():
+    output = run_command('systemctl stop nginx')
+    return jsonify({'output': output})
+
+
+@app.route('/reload', methods=['POST'])
+def reload_nginx():
+    output = run_command('systemctl reload nginx')
+    return jsonify({'output': output})
+
+
+@app.route('/sites')
+def list_sites():
+    sites = os.listdir(NGINX_SITES_AVAILABLE)
+    return jsonify({'sites': sites})
+
+
+@app.route('/sites', methods=['POST'])
+def add_site():
+    data = request.get_json(force=True)
+    domain = data.get('domain')
+    root_dir = data.get('root')
+    if not domain or not root_dir:
+        return jsonify({'error': 'domain and root are required'}), 400
+    config = f"""
+server {{
+    listen 80;
+    server_name {domain};
+    root {root_dir};
+    index index.html index.htm;
+}}
+"""
+    conf_path = os.path.join(NGINX_SITES_AVAILABLE, domain)
+    with open(conf_path, 'w') as f:
+        f.write(config)
+    # enable site
+    enabled_path = os.path.join(NGINX_SITES_ENABLED, domain)
+    if not os.path.exists(enabled_path):
+        run_command(f'ln -s {conf_path} {enabled_path}')
+    reload_output = run_command('systemctl reload nginx')
+    return jsonify({'created': domain, 'reload': reload_output})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- add a basic Flask-based control panel for Nginx
- document how to run it
- ignore Python cache files

## Testing
- `python3 -m py_compile nginx_panel/panel.py chat/server.py`

------
https://chatgpt.com/codex/tasks/task_e_685115a4e540832ab631c9b071e840ec